### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A Model Context Protocol (MCP) server that enables secure interaction with MySQL databases. This server allows AI assistants to list tables, read data, and execute SQL queries through a controlled interface, making database exploration and analysis safer and more structured.
 
+<a href="https://glama.ai/mcp/servers/vijdhok35p"><img width="380" height="200" src="https://glama.ai/mcp/servers/vijdhok35p/badge" alt="MySQL Server MCP server" /></a>
+
 ## Features
 
 - List available MySQL tables as resources


### PR DESCRIPTION
This PR adds a badge for the MySQL MCP Server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/vijdhok35p"><img width="380" height="200" src="https://glama.ai/mcp/servers/vijdhok35p/badge" alt="MySQL Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.