### PR TITLE
fix: handle result sets for SHOW INDEX and SHOW CREATE TABLE commands

### DIFF
--- a/src/mysql_mcp_server/server.py
+++ b/src/mysql_mcp_server/server.py
@@ -131,8 +131,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     result.extend([table[0] for table in tables])
                     return [TextContent(type="text", text="\n".join(result))]
                 
-                # Regular SELECT queries
-                elif query.strip().upper().startswith("SELECT"):
+                # Handle all other queries that return result sets (SELECT, SHOW, DESCRIBE etc.)
+                elif cursor.description:
                     columns = [desc[0] for desc in cursor.description]
                     rows = cursor.fetchall()
                     result = [",".join(map(str, row)) for row in rows]


### PR DESCRIPTION
### Problem
When executing `SHOW INDEX FROM table_name` or `SHOW CREATE TABLE table_name` through the MCP tool, it returns an error "Error executing query: Unread result found". 

For example:
```json
{
  "query": "SHOW INDEX FROM user_action;"
}
```
```json
{
  "query": "SHOW CREATE TABLE user_action;"
}