### PR TITLE
fix: handle python -m mysql_mcp_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
+or 
+```json
+{
+  "mcpServers": {
+    "mysql": {
+      "command": "python",
+      "args": [
+        "-m", 
+        "mysql_mcp_server"
+      ],
+      "env": {
+        "MYSQL_HOST": "localhost",
+        "MYSQL_PORT": "3306",
+        "MYSQL_USER": "your_username",
+        "MYSQL_PASSWORD": "your_password",
+        "MYSQL_DATABASE": "your_database"
+      }
+    }
+  }
+}
+
+```
+
+
 ### As a standalone server
 
 ```bash

--- a/src/mysql_mcp_server/__main__.py
+++ b/src/mysql_mcp_server/__main__.py
@@ -1,0 +1,3 @@
+from mysql_mcp_server  import main
+
+main()


### PR DESCRIPTION
添加支持python命令运行服务。
{
  "mcpServers": {
    "mysql": {
      "command": "python",
      "args": [
        "-m", 
        "mysql_mcp_server"
      ],
      "env": {
        "MYSQL_HOST": "localhost",
        "MYSQL_PORT": "3306",
        "MYSQL_USER": "your_username",
        "MYSQL_PASSWORD": "your_password",
        "MYSQL_DATABASE": "your_database"
      }
    }
  }
}