### PR TITLE
Add local docker container support to smithery.yaml configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV MYSQL_HOST=localhost
 ENV MYSQL_USER=your_username
 ENV MYSQL_PASSWORD=your_password
 ENV MYSQL_DATABASE=your_database
+ENV PYTHONPATH=/app/src
 
 # Command to run the server
-CMD ["python", "-m", "mysql_mcp_server"]
+CMD ["python", "-m", "mysql_mcp_server.server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY src/ /app/src
 
 # Set environment variables for MySQL (these can be overwritten with `docker run -e`)
-ENV MYSQL_HOST=localhost
+ENV MYSQL_HOST=host.docker.internal
+ENV MYSQL_PORT=3306
 ENV MYSQL_USER=your_username
 ENV MYSQL_PASSWORD=your_password
 ENV MYSQL_DATABASE=your_database

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,27 +6,27 @@ startCommand:
     # JSON Schema defining the configuration options for the MCP.
     type: object
     required:
-      - mysqlHost
       - mysqlUser
       - mysqlPassword
       - mysqlDatabase
     properties:
       mysqlHost:
         type: string
-        description: The hostname of the MySQL server.
+        description: "The hostname of the MySQL server. Use localhost for local connections or a specific address for remote databases. For Docker, host.docker.internal allows accessing the host machine."
+        default: "host.docker.internal"
       mysqlPort:
         type: number
-        description: The port of the MySQL server (default: 3306).
+        description: "The port of the MySQL server (default: 3306)."
         default: 3306
       mysqlUser:
         type: string
-        description: The username for MySQL authentication.
+        description: "The username for MySQL authentication."
       mysqlPassword:
         type: string
-        description: The password for MySQL authentication.
+        description: "The password for MySQL authentication."
       mysqlDatabase:
         type: string
-        description: The database to connect to.
+        description: "The database to connect to."
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,6 +14,10 @@ startCommand:
       mysqlHost:
         type: string
         description: The hostname of the MySQL server.
+      mysqlPort:
+        type: number
+        description: The port of the MySQL server (default: 3306).
+        default: 3306
       mysqlUser:
         type: string
         description: The username for MySQL authentication.
@@ -26,4 +30,17 @@ startCommand:
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({ command: 'python', args: ['-m', 'mysql_mcp_server'], env: { MYSQL_HOST: config.mysqlHost, MYSQL_USER: config.mysqlUser, MYSQL_PASSWORD: config.mysqlPassword, MYSQL_DATABASE: config.mysqlDatabase } })
+    (config) => ({ 
+      command: 'docker', 
+      args: [
+        'run',
+        '-i',
+        '--rm',
+        '-e', `MYSQL_HOST=${config.mysqlHost}`,
+        '-e', `MYSQL_PORT=${config.mysqlPort}`,
+        '-e', `MYSQL_USER=${config.mysqlUser}`,
+        '-e', `MYSQL_PASSWORD=${config.mysqlPassword}`,
+        '-e', `MYSQL_DATABASE=${config.mysqlDatabase}`,
+        'smithery/mysql-mcp-server:latest'
+      ]
+    })


### PR DESCRIPTION
Smithery maintainer here! Sending a PR to add local Docker container support to the smithery.yaml configuration.

**Changes:**
- Updated commandFunction to use the published Docker image
- Added optional MySQL port parameter with default value
- Set PYTHONPATH environment variable to ensure proper module loading

**Test:**
- Claude: 
<img width="775" alt="Screenshot 2025-03-29 at 12 15 55 PM" src="https://github.com/user-attachments/assets/5fa0fb89-1383-4b07-a540-d606184ddb56" />

```json
{
  "mcpServers": {
    "mysql": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "-e", "MYSQL_HOST=host.docker.internal",
        "-e", "MYSQL_PORT=3306", 
        "-e", "MYSQL_USER=testuser",
        "-e", "MYSQL_PASSWORD=testpass",
        "-e", "MYSQL_DATABASE=testdb",
        "smithery/mysql-mcp-server:latest"
      ]
    }
  }
}
```
