### PR TITLE
Fix: Set charset and collation to utf8mb4_general_ci to avoid unknown collation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ uv.lock
 *.dist-info/
 
 pypi_publishing_notes.md
+.qodo

--- a/src/mysql_mcp_server/server.py
+++ b/src/mysql_mcp_server/server.py
@@ -21,7 +21,10 @@ def get_db_config():
         "port": int(os.getenv("MYSQL_PORT", "3306")),
         "user": os.getenv("MYSQL_USER"),
         "password": os.getenv("MYSQL_PASSWORD"),
-        "database": os.getenv("MYSQL_DATABASE")
+        "database": os.getenv("MYSQL_DATABASE"),
+        "charset": "utf8mb4",
+        "use_unicode": True,
+        "collation": "utf8mb4_general_ci"
     }
     
     if not all([config["user"], config["password"], config["database"]]):


### PR DESCRIPTION
## Problem
When executing the SQL query, I encountered the following error:
> Unknown collation: 'utf8mb4_0900_ai_ci'

This typically happens when the MySQL server version is older and doesn't support the 'utf8mb4_0900_ai_ci' collation (which was introduced in MySQL 8.0).

## Solution
To ensure broader compatibility, I updated the database configuration to explicitly use:

- `charset`: `utf8mb4`
- `collation`: `utf8mb4_general_ci`

This collation is widely supported across MySQL versions and still provides good Unicode support.

## Notes
Tested the connection and confirmed the error no longer occurs.
