### PR TITLE
Fix: Supplement the missing symbol in the readme.md mcp.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Add this to your `mcp.json`:
         "MYSQL_PASSWORD": "your_password",
         "MYSQL_DATABASE": "your_database"
       }
+    }
   }
 }
 ```


### PR DESCRIPTION
# Problem

When I directly copy the JSON code from mcp.json in readme, it will prompt a JSON format error due to a missing symbol

![image](https://github.com/user-attachments/assets/422084b3-a421-4030-a6d4-e0b9dde12ac5)


# Solution

Add missing symbol
