### PR TITLE
feat: add charset and collation settings for compatibility with older MYSQL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ MYSQL_PORT=3306         # Optional: Database port (defaults to 3306 if not speci
 MYSQL_USER=your_username
 MYSQL_PASSWORD=your_password
 MYSQL_DATABASE=your_database
+
+# Optional: Charset and collation settings for compatibility with older MySQL versions
+MYSQL_CHARSET=utf8mb4           # Optional: Character set (defaults to utf8mb4)
+MYSQL_COLLATION=utf8mb4_unicode_ci  # Optional: Collation (defaults to utf8mb4_unicode_ci)
+MYSQL_SQL_MODE=TRADITIONAL      # Optional: SQL mode (defaults to TRADITIONAL)
+```
+
+### Troubleshooting Collation Issues
+If you encounter the error "Unknown collation: 'utf8mb4_0900_ai_ci'", this typically means you're connecting to an older MySQL version (5.7 or earlier) that doesn't support the newer collation. The server now automatically uses compatible settings, but you can override them:
+
+For MySQL 5.7 and earlier:
+```bash
+MYSQL_CHARSET=utf8mb4
+MYSQL_COLLATION=utf8mb4_unicode_ci
+```
+
+For very old MySQL versions (5.6 and earlier):
+```bash
+MYSQL_CHARSET=utf8
+MYSQL_COLLATION=utf8_unicode_ci
 ```
 
 ## Usage
@@ -44,7 +64,7 @@ Add this to your `claude_desktop_config.json`:
     "mysql": {
       "command": "uv",
       "args": [
-        "--directory", 
+        "--directory",
         "path/to/mysql_mcp_server",
         "run",
         "mysql_mcp_server"
@@ -55,6 +75,9 @@ Add this to your `claude_desktop_config.json`:
         "MYSQL_USER": "your_username",
         "MYSQL_PASSWORD": "your_password",
         "MYSQL_DATABASE": "your_database"
+        // Optional: Add these if you encounter collation issues
+        // "MYSQL_CHARSET": "utf8mb4",
+        // "MYSQL_COLLATION": "utf8mb4_unicode_ci"
       }
     }
   }
@@ -80,6 +103,9 @@ Add this to your `mcp.json`:
         "MYSQL_USER": "your_username",
         "MYSQL_PASSWORD": "your_password",
         "MYSQL_DATABASE": "your_database"
+        // Optional: Add these if you encounter collation issues
+        // "MYSQL_CHARSET": "utf8mb4",
+        // "MYSQL_COLLATION": "utf8mb4_unicode_ci"
       }
   }
 }


### PR DESCRIPTION
Before

<img width="351" alt="image" src="https://github.com/user-attachments/assets/e9d02583-8cb5-44be-8448-5801a483b1cb" />

After

<img width="351" alt="image" src="https://github.com/user-attachments/assets/82d0e468-262a-4bc4-bb3e-ea04fa1bef7e" />

env example

"env": {
        "MYSQL_CHARSET": "utf8mb4",
        "MYSQL_COLLATION": "utf8mb4_unicode_ci"
      }
