### PR TITLE
chore: update changelog and modify configuration for blank password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Made password optional by allowing blank passwords in database configuration
+- Removed password requirement from configuration validation
+
 ## [0.2.2] - 2025-04-18
 
 ### Fixed

--- a/src/mysql_mcp_server/server.py
+++ b/src/mysql_mcp_server/server.py
@@ -20,7 +20,7 @@ def get_db_config():
         "host": os.getenv("MYSQL_HOST", "localhost"),
         "port": int(os.getenv("MYSQL_PORT", "3306")),
         "user": os.getenv("MYSQL_USER"),
-        "password": os.getenv("MYSQL_PASSWORD"),
+        "password": os.getenv("MYSQL_PASSWORD", ""), # Empty string if not set
         "database": os.getenv("MYSQL_DATABASE"),
         # Add charset and collation to avoid utf8mb4_0900_ai_ci issues with older MySQL versions
         # These can be overridden via environment variables for specific MySQL versions
@@ -35,9 +35,9 @@ def get_db_config():
     # Remove None values to let MySQL connector use defaults if not specified
     config = {k: v for k, v in config.items() if v is not None}
 
-    if not all([config.get("user"), config.get("password"), config.get("database")]):
+    if not all([config.get("user"), config.get("database")]):
         logger.error("Missing required database configuration. Please check environment variables:")
-        logger.error("MYSQL_USER, MYSQL_PASSWORD, and MYSQL_DATABASE are required")
+        logger.error("MYSQL_USER and MYSQL_DATABASE are required")
         raise ValueError("Missing required database configuration")
 
     return config


### PR DESCRIPTION
While running the server locally, I encountered an error because my MySQL setup doesn’t use a password. The current logic treated the absence of a password as a misconfiguration, which caused the server to exit.

I made the password field optional in the database configuration. This doesn't affect production security practices — it's simply to support setups (like local development) where a blank password is common and acceptable.

Security remains a priority, but I wanted to make the app a bit more flexible for different environments. Happy to adjust further if needed.