### PR TITLE
Add .env file support for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ MYSQL_PASSWORD=your_password
 MYSQL_DATABASE=your_database
 ```
 
+## Local Development with .env Files
+For local development, you can use a .env file instead of setting environment variables manually:
+
+Copy .env.example to .env:
+``` bash
+ cp .env.example .env
+
+# Edit .env with your database credentials:
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_USER=your_username
+MYSQL_PASSWORD=your_password
+MYSQL_DATABASE=your_database
+```
+The server will automatically load these variables when starting
+
+
+Note: The .env file is for local development convenience. In production or when using Smithery, continue to use environment variables as documented above.
+
 ## Usage
 ### With Claude Desktop
 Add this to your `claude_desktop_config.json`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mcp>=1.0.0
 mysql-connector-python>=9.1.0
+python-dotenv>=1.0.0

--- a/src/mysql_mcp_server/.env.example
+++ b/src/mysql_mcp_server/.env.example
@@ -1,0 +1,8 @@
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_USER=your_username
+MYSQL_PASSWORD=your_password
+MYSQL_DATABASE=your_database
+MYSQL_CHARSET=utf8mb4
+MYSQL_COLLATION=utf8mb4_unicode_ci
+MYSQL_SQL_MODE=TRADITIONAL

--- a/src/mysql_mcp_server/server.py
+++ b/src/mysql_mcp_server/server.py
@@ -6,6 +6,9 @@ from mysql.connector import connect, Error
 from mcp.server import Server
 from mcp.types import Resource, Tool, TextContent
 from pydantic import AnyUrl
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Configure logging
 logging.basicConfig(


### PR DESCRIPTION
Add .env file support for local development

Changes
- Added `python-dotenv` dependency to requirements.txt
- Created `.env.example` template with all configuration variables
- Updated README.md with local development section
- Added dotenv import and load_dotenv() call to main script

Benefits
- Improves developer experience for local development and testing
- Maintains full backward compatibility with existing environment variable setup
- Follows Python best practices for environment variable management
- Makes it easier for new contributors to get started

Testing
- Tested with .env file - works correctly
- Tested without .env file - maintains backward compatibility
- All existing functionality preserved