### PR TITLE
Fix pytest error

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 testpaths = tests
+pythonpath = src
 python_files = test_*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pytest-cov>=4.1.0
 black>=23.0.0
 isort>=5.12.0
 mypy>=1.0.0
+mcp>=1.0.0
+mysql-connector-python>=9.1.0


### PR DESCRIPTION
I resolved an issue that occurred while running the project after cloning it with reference to the Development guide.

## 1. pytest can't found src/mysql_mcp_server/server.py

* To resolve this issue, I added the pythonpath to pytest.ini.

```
======================================================================================================= ERRORS =======================================================================================================
_______________________________________________________________________________________ ERROR collecting tests/test_server.py ________________________________________________________________________________________
ImportError while importing test module '/Users/hee/Desktop/mysql_mcp_server/tests/test_server.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.10/3.10.13_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_server.py:2: in <module>
    from mysql_mcp_server.server import app, list_tools, list_resources, read_resource, call_tool
E   ModuleNotFoundError: No module named 'mysql_mcp_server'
============================================================================================== short test summary info ===============================================================================================
ERROR tests/test_server.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================== 1 error in 0.12s ==================================================================================================
```

## 2. mcp and mysql-connector-python not installed

* To resolve this issue, I added the library to requirements-dev.txt.

```
ImportError while loading conftest '/Users/hee/Desktop/mysql_mcp_server/tests/conftest.py'.
tests/conftest.py:4: in <module>
    import mysql.connector
E   ModuleNotFoundError: No module named 'mysql'
```

```
======================================================================================================= ERRORS =======================================================================================================
_______________________________________________________________________________________ ERROR collecting tests/test_server.py ________________________________________________________________________________________
ImportError while importing test module '/Users/hee/Desktop/mysql_mcp_server/tests/test_server.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.10/3.10.13_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_server.py:2: in <module>
    from mysql_mcp_server.server import app, list_tools, list_resources, read_resource, call_tool
src/mysql_mcp_server/__init__.py:1: in <module>
    from . import server
src/mysql_mcp_server/server.py:6: in <module>
    from mcp.server import Server
E   ModuleNotFoundError: No module named 'mcp'
============================================================================================== short test summary info ===============================================================================================
ERROR tests/test_server.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================== 1 error in 0.12s ==================================================================================================
```