### PR TITLE
feat: add MCP tool annotation to execute_sql tool

### DIFF
--- a/src/mysql_mcp_server/server.py
+++ b/src/mysql_mcp_server/server.py
@@ -4,7 +4,7 @@ import os
 import sys
 from mysql.connector import connect, Error
 from mcp.server import Server
-from mcp.types import Resource, Tool, TextContent
+from mcp.types import Resource, Tool, TextContent, ToolAnnotations
 from pydantic import AnyUrl
 
 # Configure logging
@@ -120,7 +120,12 @@ async def list_tools() -> list[Tool]:
                     }
                 },
                 "required": ["query"]
-            }
+            },
+            annotations=ToolAnnotations(
+                title="Execute SQL",
+                readOnlyHint=False,
+                destructiveHint=True
+            )
         )
     ]
 


### PR DESCRIPTION
## Summary

Add MCP tool annotations to the `execute_sql` tool to help LLM clients understand the tool's safety characteristics.

## Changes

- Added `ToolAnnotations` import from `mcp.types`
- Added annotations to `execute_sql` tool:
  - `title`: "Execute SQL"
  - `readOnlyHint`: `False` - tool can execute INSERT, UPDATE, DELETE queries
  - `destructiveHint`: `True` - tool can execute DROP TABLE, DROP DATABASE queries

## Why This Matters

The `execute_sql` tool can run **any SQL query**, including:
- Read operations: `SELECT`, `SHOW`, `DESCRIBE`
- Write operations: `INSERT`, `UPDATE`, `DELETE`
- Destructive operations: `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`

Without annotations, MCP clients (like Claude) have no way to know the tool can modify or destroy data. Adding `destructiveHint: True` helps the LLM exercise appropriate caution when using this tool.

## Test Plan

- [x] Minimal change (1 file, 7 lines added)
- [x] Uses standard MCP SDK `ToolAnnotations` class
- [x] No functional changes to tool behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)